### PR TITLE
Add project badges and Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
           path: coverage
           if-no-files-found: warn
 
+      - name: Upload coverage to Codecov
+        if: matrix.node == 22
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+
   # Release-readiness: the packed tarball ships dist + docs and nothing extraneous (task 34).
   package:
     name: package (npm pack)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # 🦎 Agama — Redmine MCP Server
 
+[![npm version](https://img.shields.io/npm/v/@0xkillaflow/agama-redmine-mcp.svg)](https://www.npmjs.com/package/@0xkillaflow/agama-redmine-mcp)
+[![License](https://img.shields.io/github/license/0xkillaflow/agama-redmine-mcp.svg)](LICENSE)
+[![Node Version](https://img.shields.io/node/v/@0xkillaflow/agama-redmine-mcp.svg)](package.json)
+[![GitHub Issues](https://img.shields.io/github/issues/0xkillaflow/agama-redmine-mcp.svg)](https://github.com/0xkillaflow/agama-redmine-mcp/issues)
+[![CI](https://github.com/0xkillaflow/agama-redmine-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/0xkillaflow/agama-redmine-mcp/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/0xkillaflow/agama-redmine-mcp/branch/master/graph/badge.svg)](https://codecov.io/gh/0xkillaflow/agama-redmine-mcp)
+[![npm downloads](https://img.shields.io/npm/dm/@0xkillaflow/agama-redmine-mcp.svg)](https://www.npmjs.com/package/@0xkillaflow/agama-redmine-mcp)
+
 [MCP server](https://modelcontextprotocol.io/) for Redmine. Enables AI agents to work with issues using simple natural language commands.
 
 Works just as well as a personal tool for a single developer — or deployed once and shared by the

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/**'],
+      reporter: ['text', 'html', 'lcov'],
       thresholds: {
         'src/domain/**': { statements: 80, branches: 80, functions: 80, lines: 80 },
         'src/application/**': { statements: 80, branches: 80, functions: 80, lines: 80 },


### PR DESCRIPTION
Adds npm/license/node/issues/CI/coverage/downloads badges to the README, uploads coverage to Codecov from CI, and enables the lcov reporter in Vitest so Codecov has a report to ingest.